### PR TITLE
Fixed typo when parsing for 'tomorrow' / Added parser to allow text like 'next <day of week>'

### DIFF
--- a/HumanDateParser.Tests/Tests.cs
+++ b/HumanDateParser.Tests/Tests.cs
@@ -19,6 +19,32 @@ namespace HumanDateParser.Tests
         }
 
         [TestMethod]
+        public void NextMondayTest()
+        {
+            var offset = (7 - (int)DateTime.Now.DayOfWeek) + 1;
+            var actual = DateTime.Now.AddDays(offset) ;
+            var parsed = DateParser.Parse("next monday");
+
+            Assert.IsNotNull(parsed);
+            Assert.AreEqual(actual.Year, parsed.Year);
+            Assert.AreEqual(actual.Month, parsed.Month);
+            Assert.AreEqual(actual.Date, parsed.Date);
+        }
+
+        [TestMethod]
+        public void NextThursdayTest()
+        {
+            var offset = (7 - (int)DateTime.Now.DayOfWeek) + 4;
+            var actual = DateTime.Now.AddDays(offset);
+            var parsed = DateParser.Parse("next thursday");
+
+            Assert.IsNotNull(parsed);
+            Assert.AreEqual(actual.Year, parsed.Year);
+            Assert.AreEqual(actual.Month, parsed.Month);
+            Assert.AreEqual(actual.Date, parsed.Date);
+        }
+
+        [TestMethod]
         public void TomorrowTest()
         {
             var actual = DateTime.Now.AddDays(1);

--- a/HumanDateParser.Tests/Tests.cs
+++ b/HumanDateParser.Tests/Tests.cs
@@ -7,6 +7,30 @@ namespace HumanDateParser.Tests
     public class Tests
     {
         [TestMethod]
+        public void TodayTest()
+        {
+            var actual = DateTime.Now;
+            var parsed = DateParser.Parse("today");
+
+            Assert.IsNotNull(parsed);
+            Assert.AreEqual(actual.Year, parsed.Year);
+            Assert.AreEqual(actual.Month, parsed.Month);
+            Assert.AreEqual(actual.Date, parsed.Date);
+        }
+
+        [TestMethod]
+        public void TomorrowTest()
+        {
+            var actual = DateTime.Now.AddDays(1);
+            var parsed = DateParser.Parse("tomorrow");
+
+            Assert.IsNotNull(parsed);
+            Assert.AreEqual(actual.Year, parsed.Year);
+            Assert.AreEqual(actual.Month, parsed.Month);
+            Assert.AreEqual(actual.Date, parsed.Date);
+        }
+
+        [TestMethod]
         public void MonthTest()
         {
             var actual = DateTime.Now.AddMonths(-1);

--- a/HumanDateParser/Lexer.cs
+++ b/HumanDateParser/Lexer.cs
@@ -81,8 +81,8 @@ namespace HumanDateParser
                 case "TODAY":
                     returnToken = new Token(TokenKind.TODAY, "<today>");
                     break;
-                case "TOMMOROW":
-                    returnToken = new Token(TokenKind.TOMMOROW, "<tommorow>");
+                case "TOMORROW":
+                    returnToken = new Token(TokenKind.TOMORROW, "<tomorrow>");
                     break;
                 case "YESTERDAY":
                     returnToken = new Token(TokenKind.YESTERDAY, "<yesterday>");

--- a/HumanDateParser/Parser.cs
+++ b/HumanDateParser/Parser.cs
@@ -83,7 +83,7 @@ namespace HumanDateParser
                     Load();
                     break;
                 case TokenKind.DAY_IDENTIFIER:
-                    DayDateIdent(Peek(1).Text);
+                    DayDateIdent(Peek(1).Text, TokenKind.DAY);
                     Load();
                     break;
                 case TokenKind.NUMBER:
@@ -182,13 +182,23 @@ namespace HumanDateParser
                 _dateRange.AddDate(new DateTime(DateTime.Now.Year, DateTime.Now.Month, num));
         }
 
-        private void DayDateIdent(string dayString)
+        private void DayDateIdent(string dayString, TokenKind tokenKind)
         {
+            DateTime pivotDate;
+            if (tokenKind == TokenKind.NEXT)
+            {
+                pivotDate = Today.AddDays(1);
+            }
+            else
+            {
+                pivotDate = Today;
+            }
+
             for (var i = 0; i < 7; i++ )
             {
-                if (Today.AddDays(i).DayOfWeek == (DayOfWeek)Enum.Parse(typeof(DayOfWeek), dayString, true))
+                if (pivotDate.AddDays(i).DayOfWeek == (DayOfWeek)Enum.Parse(typeof(DayOfWeek), dayString, true))
                 {
-                    _dateRange.AddDate(Today.AddDays(i));
+                    _dateRange.AddDate(pivotDate.AddDays(i));
                     return;
                 }
             }
@@ -200,6 +210,10 @@ namespace HumanDateParser
             if (Peek(2).Kind == TokenKind.AGO) num = num * -1;
             switch (Peek(1).Kind)
             {
+                case TokenKind.DAY_IDENTIFIER:
+                    DayDateIdent(Peek(1).Text, TokenKind.NEXT);
+                    Load();
+                    break;
                 case TokenKind.DAY:
                     _dateRange.AddDate(Today.AddDays(num));
                     Load();

--- a/HumanDateParser/Parser.cs
+++ b/HumanDateParser/Parser.cs
@@ -74,7 +74,7 @@ namespace HumanDateParser
                     _dateRange.AddDate(Today);
                     Load();
                     break;
-                case TokenKind.TOMMOROW:
+                case TokenKind.TOMORROW:
                     _dateRange.AddDate(Today.AddDays(1));
                     Load();
                     break;

--- a/HumanDateParser/TokenKind.cs
+++ b/HumanDateParser/TokenKind.cs
@@ -11,7 +11,7 @@
         TIME_MODIFIER,
         DAY_IDENTIFIER,
         TODAY,
-        TOMMOROW,
+        TOMORROW,
         YESTERDAY,
         DATE_IDENTIFIER,
         NUMBER,


### PR DESCRIPTION
Token for **tomorrow** was mispelled. I fixed all occurrences and wrote tests for 'TODAY' and 'TOMORROW'.